### PR TITLE
Web UI: add `python-websockify` as Anvil dependency

### DIFF
--- a/configs/centos-8-stream-package-list
+++ b/configs/centos-8-stream-package-list
@@ -1,4 +1,4 @@
-anvildeps="htop screen perl-UUID-Tiny perl-Proc-Simple perl-Net-SSH2 perl-Net-OpenSSH perl-Net-Netmask perl-Net-Domain-TLD perl-Mail-RFC822-Address perl-HTML-Strip perl-HTML-FromText perl-Data-Validate-IP perl-Data-Validate-Domain perl-Log-Journald drbd-utils drbd91-kmod"
+anvildeps="htop screen perl-UUID-Tiny perl-Proc-Simple perl-Net-SSH2 perl-Net-OpenSSH perl-Net-Netmask perl-Net-Domain-TLD perl-Mail-RFC822-Address perl-HTML-Strip perl-HTML-FromText perl-Data-Validate-IP perl-Data-Validate-Domain perl-Log-Journald drbd-utils drbd91-kmod python-websockify"
 
 installdeps="perl-Moo perl-Object-Remote perl-Eval-WithLexicals perl-Curses perl-Curses-UI"
 

--- a/configs/rhel-8-package-list
+++ b/configs/rhel-8-package-list
@@ -1,4 +1,4 @@
-anvildeps="htop screen perl-UUID-Tiny perl-Proc-Simple perl-Net-SSH2 perl-Net-OpenSSH perl-Net-Netmask perl-Net-Domain-TLD perl-Mail-RFC822-Address perl-HTML-Strip perl-HTML-FromText perl-Data-Validate-IP perl-Data-Validate-Domain perl-Log-Journald drbd-utils drbd91-kmod"
+anvildeps="htop screen perl-UUID-Tiny perl-Proc-Simple perl-Net-SSH2 perl-Net-OpenSSH perl-Net-Netmask perl-Net-Domain-TLD perl-Mail-RFC822-Address perl-HTML-Strip perl-HTML-FromText perl-Data-Validate-IP perl-Data-Validate-Domain perl-Log-Journald drbd-utils drbd91-kmod python-websockify"
 
 installdeps="perl-Moo perl-Object-Remote perl-Eval-WithLexicals perl-Curses perl-Curses-UI"
 

--- a/srpms/python-websockify/build.sh
+++ b/srpms/python-websockify/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+spec_filename="python-websockify.spec"
+working_directory="$(pwd)"
+
+rm -f *.tar.gz
+spectool --get-files --sources --define "_srcrpmdir $working_directory" --define "_sourcedir $working_directory" "$spec_filename"
+rpmbuild --define "_srcrpmdir $working_directory" --define "_sourcedir $working_directory" --nodeps -bs "$spec_filename"
+rm -f *.tar.gz
+

--- a/srpms/python-websockify/python-websockify.spec
+++ b/srpms/python-websockify/python-websockify.spec
@@ -1,0 +1,171 @@
+%global pkgname websockify
+%global summary WSGI based adapter for the Websockets protocol
+Name:           python-%{pkgname}
+Version:        0.9.0
+Release:        4%{?dist}
+Summary:        %{summary}
+
+License:        LGPLv3
+URL:            https://github.com/novnc/websockify
+Source0:        https://github.com/novnc/websockify/archive/v%{version}.tar.gz
+BuildArch:      noarch
+
+%description
+Python WSGI based adapter for the Websockets protocol
+
+%package -n python3-%{pkgname}
+Summary:        %{summary} - Python 3 version
+BuildRequires:  python36-devel
+BuildRequires:  python3-setuptools
+
+Requires:       python3-setuptools
+
+%{?python_provide:%python_provide python3-%{pkgname}}
+
+%description -n python3-%{pkgname}
+Python WSGI based adapter for the Websockets protocol - Python 3 version
+
+%package doc
+Summary:        %{summary} - documentation
+
+%description doc
+Python WSGI based adapter for the Websockets protocol - documentation
+
+%prep
+%autosetup -n %{pkgname}-%{version}
+
+# TODO: Have the following handle multi line entries
+sed -i '/setup_requires/d; /install_requires/d; /dependency_links/d' setup.py
+
+%build
+%py3_build
+
+%install
+%py3_install
+
+rm -Rf %{buildroot}/usr/share/websockify
+mkdir -p %{buildroot}%{_mandir}/man1/
+install -m 444 docs/websockify.1 %{buildroot}%{_mandir}/man1/
+
+%files -n python3-%{pkgname}
+%license COPYING
+%{_mandir}/man1/websockify.1*
+%{python3_sitelib}/websockify/
+%{python3_sitelib}/websockify-%{version}-py%{python3_version}.egg-info
+%{_bindir}/websockify
+
+%files doc
+%license COPYING
+%doc docs
+
+%changelog
+* Fri Jun 25 2021 Yanhao Lei <yanhao.lei@alteeve.com> - 0.9.0-4
+- Rebuilt for RHEL 8 and CentOS 8
+
+* Wed Jul 29 2020 Fedora Release Engineering <releng@fedoraproject.org> - 0.9.0-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_33_Mass_Rebuild
+
+* Tue May 26 2020 Miro Hrončok <mhroncok@redhat.com> - 0.9.0-2
+- Rebuilt for Python 3.9
+
+* Thu Mar 26 2020 Yatin Karel <ykarel@redhat.com> - 0.9.0-1
+- Update to 0.9.0 (Resolves #1816608)
+
+* Thu Jan 30 2020 Fedora Release Engineering <releng@fedoraproject.org> - 0.8.0-16
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_32_Mass_Rebuild
+
+* Thu Oct 03 2019 Miro Hrončok <mhroncok@redhat.com> - 0.8.0-15
+- Rebuilt for Python 3.8.0rc1 (#1748018)
+
+* Mon Aug 19 2019 Miro Hrončok <mhroncok@redhat.com> - 0.8.0-14
+- Rebuilt for Python 3.8
+
+* Sun Aug 11 2019 Miro Hrončok <mhroncok@redhat.com> - 0.8.0-13
+- Subpackage python2-websockify has been removed
+  See https://fedoraproject.org/wiki/Changes/Mass_Python_2_Package_Removal
+
+* Fri Jul 26 2019 Fedora Release Engineering <releng@fedoraproject.org> - 0.8.0-12
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_31_Mass_Rebuild
+
+* Sat Feb 02 2019 Fedora Release Engineering <releng@fedoraproject.org> - 0.8.0-11
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_30_Mass_Rebuild
+
+* Sat Jul 14 2018 Fedora Release Engineering <releng@fedoraproject.org> - 0.8.0-10
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_29_Mass_Rebuild
+
+* Tue Jun 19 2018 Miro Hrončok <mhroncok@redhat.com> - 0.8.0-9
+- Rebuilt for Python 3.7
+
+* Fri Feb 16 2018 2018 Lumír Balhar <lbalhar@redhat.com> - 0.8.0-8
+- Fix directory ownership
+
+* Fri Feb 09 2018 Fedora Release Engineering <releng@fedoraproject.org> - 0.8.0-7
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_28_Mass_Rebuild
+
+* Thu Jul 27 2017 Fedora Release Engineering <releng@fedoraproject.org> - 0.8.0-6
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_27_Mass_Rebuild
+
+* Sat Feb 11 2017 Fedora Release Engineering <releng@fedoraproject.org> - 0.8.0-5
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_26_Mass_Rebuild
+
+* Mon Dec 19 2016 Miro Hrončok <mhroncok@redhat.com> - 0.8.0-4
+- Rebuild for Python 3.6
+
+* Mon Aug 29 2016 Jan Beran <jberan@redhat.com> - 0.8.0-3
+- Python 3 subpackage
+
+* Tue Jul 19 2016 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.8.0-2
+- https://fedoraproject.org/wiki/Changes/Automatic_Provides_for_Python_RPM_Packages
+
+* Fri Feb 19 2016 Solly Ross <sross@redhat.com> - 0.8.0-1
+- Update to release 0.8.0
+
+* Thu Feb 04 2016 Fedora Release Engineering <releng@fedoraproject.org> - 0.6.0-4
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_24_Mass_Rebuild
+
+* Thu Jun 18 2015 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.6.0-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_23_Mass_Rebuild
+
+* Wed Apr 29 2015 Pádraig Brady <pbrady@redhat.com> - 0.6.0-2
+- Support big endian systems - rhbz#1216219
+
+* Mon Mar 23 2015 Nikola Đipanov <ndipanov@redhat.com> - 0.6.0-1
+- Update to release 0.6.0
+
+* Sun Jun 08 2014 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.5.1-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_21_Mass_Rebuild
+
+* Tue Sep 10 2013 Nikola Đipanov <ndipanov@redhat.com> - 0.5.1-1
+- Update to release 0.5.1
+
+* Sun Aug 04 2013 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.4.1-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_20_Mass_Rebuild
+
+* Thu Jun 20 2013 Pádraig Brady <P@draigBrady.com> - 0.4.1-1
+- Update to release 0.4.1
+
+* Tue Mar 12 2013 Pádraig Brady <P@draigBrady.com> - 0.2.0-4
+- Add runtime dependency on setuptools
+
+* Thu Feb 14 2013 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.2.0-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_19_Mass_Rebuild
+
+* Wed Oct 31 2012 Pádraig Brady <P@draigBrady.com> - 0.2.0-2
+- Remove hard dependency on numpy
+
+* Mon Oct 22 2012 Nikola Đipanov <ndipanov@redhat.com> - 0.2.0-1
+- Moving to the upstream version 0.2.0
+
+* Sat Jul 21 2012 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.1.0-6
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_18_Mass_Rebuild
+
+* Wed Jun 6 2012 Adam Young <ayoung@redhat.com> - 0.1.0-4
+- Added Description
+- Added Manpage
+
+* Fri May 11 2012 Matthias Runge <mrunge@matthias-runge.de> - 0.1.0-2
+- spec cleanup
+
+* Thu May 10 2012 Adam Young <ayoung@redhat.com> - 0.1.0-1
+- Initial RPM release.
+


### PR DESCRIPTION
The package `python-websockify` is a copy from the Fedora repos with minor changes to:
1. source URL,
2. `BuildRequires` to strictly use Python 3.6, and
3. release number and change log.

Notes in `build.sh`: `spectool` is capable of pulling the source files, thus `wget` is not needed.